### PR TITLE
Fix generate_protenix_test_command error

### DIFF
--- a/abcfold/protenix/run_protenix.py
+++ b/abcfold/protenix/run_protenix.py
@@ -169,6 +169,6 @@ def generate_protenix_test_command() -> list:
 
     return [
         "protenix",
-        "predict",
+        "pred",
         "--help",
     ]


### PR DESCRIPTION
Command "predict" is unknown. Replace "predict" with "pred".